### PR TITLE
Ipv6 support

### DIFF
--- a/cmd/server/go.mod
+++ b/cmd/server/go.mod
@@ -2,4 +2,4 @@ module github.com/drewwalton19216801/padserve/padserve_server
 
 go 1.23.2
 
-require github.com/drewwalton19216801/tailutils v0.1.0
+require github.com/drewwalton19216801/tailutils v0.2.0

--- a/cmd/server/go.sum
+++ b/cmd/server/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drewwalton19216801/tailutils v0.1.0 h1:mDJZGE4DGf8BU9DV94l2TkbH/ptfLeXb1NX58dmi8qg=
-github.com/drewwalton19216801/tailutils v0.1.0/go.mod h1:5O+Sy7YFSc02x3FcQIvjPZ2/BLlkEMuq0EiEiEOULJQ=
+github.com/drewwalton19216801/tailutils v0.2.0 h1:HWdw3VSgJrC7shwfhd2qSE4Jp00C/y1kgPkhR72zDOM=
+github.com/drewwalton19216801/tailutils v0.2.0/go.mod h1:5O+Sy7YFSc02x3FcQIvjPZ2/BLlkEMuq0EiEiEOULJQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -243,11 +243,25 @@ func handleClient(conn net.Conn) {
 			conn.Write([]byte("LISTED\n"))
 		} else if strings.HasPrefix(message, "INFO") {
 			// Print server information
-			tailscaleIP, err := tailutils.GetTailscaleIP()
-			if err != nil {
-				conn.Write([]byte("ERROR Failed to get Tailscale IP: " + err.Error() + "\n"))
+
+			// Get the IP address(es) we are currently listening on
+			tailscaleIP4, ip4err := tailutils.GetTailscaleIP()
+			tailscaleIP6, ip6err := tailutils.GetTailscaleIP6()
+			tailscaleIP := ""
+
+			// If both error, we don't have a Tailscale IP
+			if ip4err == nil && ip6err == nil {
+				tailscaleIP = fmt.Sprintf("%s, %s", tailscaleIP4, tailscaleIP6)
+			} else if ip4err == nil {
+				tailscaleIP = tailscaleIP4
+			} else if ip6err == nil {
+				tailscaleIP = tailscaleIP6
+			}
+
+			if ip4err != nil && ip6err != nil {
+				conn.Write([]byte("INFO No Tailscale IP\n"))
 			} else {
-				conn.Write([]byte(fmt.Sprintf("INFO Tailscale IP: %s\n", tailscaleIP)))
+				conn.Write([]byte(fmt.Sprintf("INFO Tailscale IP(s): %s\n", tailscaleIP)))
 
 				// Print connected clients
 				clientMutex.RLock()


### PR DESCRIPTION
These changes enable IPv6 support by using version 0.2.0 of `tailutils`. Client changes were not necessary.